### PR TITLE
Add /plans endpoint

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -10,6 +10,7 @@ import customers from './resources/customers';
 import paymentProfiles from './resources/payment-profiles';
 import payments from './resources/payments';
 import subscriptions from './resources/subscriptions';
+import plans from './resources/plans';
 
 import packageJson from '../../package.json';
 
@@ -39,6 +40,7 @@ async function main() {
   api.use('/payment_profiles', paymentProfiles());
   api.use('/payments', payments());
   api.use('/subscriptions', subscriptions());
+  api.use('/plans', plans());
 
   app.use('/v1', api);
 

--- a/api/src/resources/plans/index.js
+++ b/api/src/resources/plans/index.js
@@ -1,0 +1,8 @@
+import createRouter from './routes';
+import logger from '../../logging';
+
+const log = logger('Plans');
+
+export default function () {
+  return createRouter(log);
+}

--- a/api/src/resources/plans/routes.js
+++ b/api/src/resources/plans/routes.js
@@ -1,0 +1,34 @@
+import { Router } from 'express';
+import { handleValidationFailure } from '../../errors';
+import { validateKnownParams } from '../../validation/helpers';
+
+export default function createRouter(log) {
+  const router = new Router();
+
+  router.get('/', async (req, res, next) => {
+    log.info(`GET ${req.url}`);
+
+    const knownParams = [ 'currency' ];
+    const unknownParamsErrors = validateKnownParams(knownParams, req.query);
+    const validationResult = await req.getValidationResult();
+    if (!validationResult.isEmpty() || unknownParamsErrors.length) {
+      handleValidationFailure([ ...validationResult.array(), ...unknownParamsErrors ], res);
+      return;
+    }
+
+    res.json({
+      data: [
+        {
+          uuid: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+          amount: 10,
+          currency: 'usd',
+          interval: 'day',
+          nickname: 'WeWork Now Unlimited',
+          is_active: true,
+        },
+      ],
+    });
+  });
+
+  return router;
+}


### PR DESCRIPTION
The on-demand mock server didn't have support for the `/plans` endpoint. I need this endpoint to enable progress on the on demand app, so I wrote a simple GET endpoint into the mock server and figured that others may want to use it as well.